### PR TITLE
feat: access values of previous properties as variables

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,5 @@
 type User {
-  name: String @generate(data: "faker.person.fullName()")
-  avatar_url: String @generate(data: "faker.internet.avatar()")
+  firstName: String @generate(data: "faker.person.firstName()")
+  lastName: String @generate(data: "faker.person.lastName()")
+  emailID: String @generate(data: "faker.internet.email({ firstName: firstName, lastName: lastName })")
 }

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -33,7 +33,7 @@ const generateAction = async (options: GenerateOptions) => {
 
       const typeName = definition.name.value
   
-      // documentsForType is initialized with NUM_DOCUMENTS empty objects
+      // documentsForType is initialized with options.numDocuments empty objects
       const documentsForType: any[] = [...Array(options.numDocuments).keys()].map(i => {
         let emptyObj = {}
         return emptyObj
@@ -108,13 +108,18 @@ const generateAction = async (options: GenerateOptions) => {
   
         // Generate fake data and put it into documentsForType
         for (let i = 0; i < options.numDocuments; i++) {
-          const fakeData = evaluator.eval(dataScript, { faker: faker })
+          const fakeData = evaluator.eval(dataScript,
+            {
+              faker: faker,
+              console: console,
+              ...documentsForType[i]
+            }
+          )
           documentsForType[i][fieldName] = fakeData
         }
       }
-  
+
       // Export documentsForType to JSON
-  
       if (!fs.existsSync(`./datagen/`)) {
         await fsPromises.mkdir(`./datagen/`, { recursive: true })
       }


### PR DESCRIPTION
Added a feature that allows users to access the values of previous schema fields as variables. These variables can be used in the `data` argument for the `@generate` directive which accepts runnable Javascript.

Example:
```graphql
type User {
  firstName: String @generate(data: "faker.person.firstName()")
  lastName: String @generate(data: "faker.person.lastName()")
  emailID: String @generate(data: "faker.internet.email({ firstName: firstName, lastName: lastName })")
}
```

In this case, we generate an email using a specific `firstName` and `lastName` that we want `emailID` to have. The `firstName` and `lastName` variables come from the `firstName` and `lastName` fields defined under `type User`.

In general, this feature allows you to generate more realistic results using previously generated data.