### PR TITLE
feat: use variables during data generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,9 @@
         "@faker-js/faker": "^8.0.2",
         "chalk": "^4.1.2",
         "commander": "^11.0.0",
-        "dedent-js": "^1.0.1",
         "firebase-admin": "^11.10.1",
         "graphql": "^16.7.1",
-        "pluralize": "^8.0.0",
-        "scoped-eval": "^0.4.2"
+        "pluralize": "^8.0.0"
       },
       "bin": {
         "gqlfake": "dist/cli.js"
@@ -27,9 +25,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+      "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
       "optional": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -437,9 +435,9 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.6.tgz",
-      "integrity": "sha512-q0RkvNgMweWWIvSMDiXhflGUKMdIxBo2M2tYM/0kEGDueQByFzK4KZAgu5YHGFNxziTlppNpTIBcqHQAxlfHdA=="
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q=="
     },
     "node_modules/@types/pluralize": {
       "version": "0.0.30",
@@ -732,11 +730,6 @@
         }
       }
     },
-    "node_modules/dedent-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
-      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -843,9 +836,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "optional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1130,9 +1123,9 @@
       "optional": true
     },
     "node_modules/graphql": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-      "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+      "version": "16.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
+      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -1875,14 +1868,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/scoped-eval": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/scoped-eval/-/scoped-eval-0.4.2.tgz",
-      "integrity": "sha512-cewe5fPPQz1CfEcTdQtUnPCCaX2GWoGHuKnRjtkFfKu1EQlhaQEDjWs366X/1YzlwjgWuiR1tanAqbECssLtkw==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/semver": {
       "version": "7.5.4",

--- a/package.json
+++ b/package.json
@@ -2,17 +2,16 @@
   "name": "gqlfake",
   "version": "0.1.5",
   "description": "A CLI tool that can be used to create fake, structured data using GraphQL schemas to specify fields and data types",
-
   "main": "dist/index.js",
   "bin": "dist/cli.js",
   "types": "dist",
-  "files": ["dist"],
-
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npx tsc"
   },
-
   "keywords": [
     "fake",
     "data",
@@ -25,7 +24,6 @@
     "type": "git",
     "url": "https://github.com/DudeBro249/gqlfake"
   },
-
   "devDependencies": {
     "@types/pluralize": "^0.0.30",
     "typescript": "^5.1.6"
@@ -34,10 +32,8 @@
     "@faker-js/faker": "^8.0.2",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
-    "dedent-js": "^1.0.1",
     "firebase-admin": "^11.10.1",
     "graphql": "^16.7.1",
-    "pluralize": "^8.0.0",
-    "scoped-eval": "^0.4.2"
+    "pluralize": "^8.0.0"
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,25 @@
 type User {
-  firstName: String @generate(data: "faker.person.firstName()")
-  lastName: String @generate(data: "faker.person.lastName()")
-  emailID: String @generate(data: "faker.internet.email({ firstName: firstName, lastName: lastName })")
+  firstName: String 
+    @generate(
+      data: """
+      firstName = faker.person.firstName()
+      return firstName
+      """
+    )
+  lastName: String 
+    @generate(
+      data: """
+      lastName = faker.person.lastName()
+      return lastName
+      """
+    )
+  emailID: String
+    @generate(
+      data: """
+      return faker.internet.email({
+        firstName: firstName,
+        lastName: lastName
+      })
+      """
+    )
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ const TOOL_DESCRIPTION = 'A CLI tool that can be used to create fake, structured
 const VERSION = '0.1.5'
 
 const GENERATE_DIRECTIVE_NAME = 'generate'
-const GENERATE_DIRECTIVE_ARGUMENT_NAME = 'data'
+const GENERATE_DIRECTIVE_DATA_ARGUMENT_NAME = 'data'
 
 export {
     TOOL_NAME,
@@ -11,5 +11,5 @@ export {
 
     VERSION,
     GENERATE_DIRECTIVE_NAME,
-    GENERATE_DIRECTIVE_ARGUMENT_NAME
+    GENERATE_DIRECTIVE_DATA_ARGUMENT_NAME
 }


### PR DESCRIPTION
- Allow users to define and use variables across GraphQL schema

Example:
```graphql
type User {
  firstName: String 
    @generate(
      data: """
      firstName = faker.person.firstName()
      return firstName
      """
    )
  lastName: String 
    @generate(
      data: """
      lastName = faker.person.lastName()
      return lastName
      """
    )
  emailID: String
    @generate(
      data: """
      return faker.internet.email({
        firstName: firstName,
        lastName: lastName
      })
      """
    )
}
```

The above example defines and uses variables `firstName` and `lastName` to generate data for field `emailID`.