### PR TITLE
feat: add command to compile all generated data into one file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import { generateCommand } from './commands/generate';
-import { exportFirestoreCommand } from './commands/exportFirestore';
 import { TOOL_DESCRIPTION, VERSION } from './constants';
+import {
+  generateCommand,
+  exportFirestoreCommand,
+  compileCommand
+} from './commands';
 
 
 const main = async () => {
@@ -15,6 +18,7 @@ const main = async () => {
   program
   .addCommand(generateCommand)
   .addCommand(exportFirestoreCommand)
+  .addCommand(compileCommand)
   
 
   program.parse()

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,0 +1,88 @@
+import * as fsPromises from 'fs/promises'
+import { Command } from 'commander';
+import * as path from 'path'
+import { errorStyle, infoStyle } from '../textStyles';
+import { TOOL_NAME } from '../constants';
+import pluralize from 'pluralize';
+
+interface CompileOptions {
+    outputPath: string
+}
+
+const compileAction = async (options: CompileOptions) => {
+    const fileExtension = path.extname(options.outputPath)
+    const relativeOutputPath = path.relative('./', options.outputPath) // For output purposes
+
+    if (fileExtension !== '.json') {
+        console.error(
+            errorStyle(`Cannot write to ${options.outputPath} because it is not a JSON file!`)
+        );
+        
+        process.exit(1)
+    }
+
+    // Get the names of all files in the datagen directory
+    let filenames: string[] = [];
+    try {
+        const absoluteDataDirectoryPath = path.resolve('./datagen');
+        filenames = await fsPromises.readdir(absoluteDataDirectoryPath);
+    } catch (error: any) {
+        if (error.code === 'ENOENT') {
+            console.error(
+                errorStyle(
+                    `Couldn't find a datagen directory. Use the \`${TOOL_NAME} generate\` command to create one. Run \`${TOOL_NAME} generate --help\` to learn more about the generate command.`
+                )
+            );
+        }
+
+        process.exit(1);
+    }
+
+    // Object containing all the compiled data
+    // Each key will contain the data from each generated file
+    const compiledData: { [key: string]: object[] } = {}
+
+    filenames.forEach((filename) => {
+        const filenameWithoutExtension = path.parse(filename).name;
+        const keyName = pluralize(filenameWithoutExtension).toLowerCase();
+
+        // Absolute and relative file paths to the file to be read from
+        const absoluteFilePath = path.resolve(`./datagen/${filename}`);
+        const relativeFilePath = path.relative('./', absoluteFilePath)
+
+        // This check is necessary because the output file could be in the datagen
+        // directory as well
+        if (absoluteFilePath === options.outputPath) {
+            // Don't process the output file itself - we don't need to read data from it
+            return; 
+        }
+
+        console.log(infoStyle(`Adding documents from ${relativeFilePath} to key "${keyName}" in ${relativeOutputPath}"`));
+
+        const data: object[] = require(absoluteFilePath);
+        compiledData[keyName] = data;
+    });
+
+    await fsPromises.writeFile(
+        options.outputPath,
+        JSON.stringify(compiledData, null, 2)
+    )
+
+    console.log(infoStyle(`Compiled data has been written to ${options.outputPath}`));
+}
+
+
+// Create the compile command
+const compileCommand = new Command()
+                    .name('compile')
+                    .description('Compiles all generated data into one file')
+                    .option(
+                        '-o, --output-path <path>',
+                        'The path to the JSON file that you want to compile all the data to',
+                        (value: any) => path.resolve(value),
+                        path.resolve('./datagen/db.json') // default value
+                    )
+                    .action(compileAction)
+
+
+export { compileCommand, compileAction, CompileOptions }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,2 +1,3 @@
+export * from './compile'
 export * from './exportFirestore'
 export * from './generate'


### PR DESCRIPTION
- Added command `compile`. This command allows users to compile all generated data (across all files in the `datagen` directory) into one file specified by `--output-path`. The default output path is `./datagen/db.json`.

- Example Use Case for this Feature: Users who want to use [`json-server`](https://www.npmjs.com/package/json-server) need one JSON file to serve data from. The `gqlfake compile` command comes in handy here.