### PR TITLE
feat: dependency injection

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import { errorStyle, infoStyle } from '../textStyles';
 import { TOOL_NAME } from '../constants';
 import pluralize from 'pluralize';
+import { getAbsolutePOSIXPath } from '../utils/absolutePosixPath';
 
 interface CompileOptions {
     outputPath: string
@@ -24,7 +25,7 @@ const compileAction = async (options: CompileOptions) => {
     // Get the names of all files in the datagen directory
     let filenames: string[] = [];
     try {
-        const absoluteDataDirectoryPath = path.resolve('./datagen');
+        const absoluteDataDirectoryPath = getAbsolutePOSIXPath('./datagen');
         filenames = await fsPromises.readdir(absoluteDataDirectoryPath);
     } catch (error: any) {
         if (error.code === 'ENOENT') {
@@ -47,7 +48,7 @@ const compileAction = async (options: CompileOptions) => {
         const keyName = pluralize(filenameWithoutExtension).toLowerCase();
 
         // Absolute and relative file paths to the file to be read from
-        const absoluteFilePath = path.resolve(`./datagen/${filename}`);
+        const absoluteFilePath = getAbsolutePOSIXPath(`./datagen/${filename}`);
         const relativeFilePath = path.relative('./', absoluteFilePath)
 
         // This check is necessary because the output file could be in the datagen
@@ -79,8 +80,8 @@ const compileCommand = new Command()
                     .option(
                         '-o, --output-path <path>',
                         'The path to the JSON file that you want to compile all the data to',
-                        (value: any) => path.resolve(value),
-                        path.resolve('./datagen/db.json') // default value
+                        (value: any) => getAbsolutePOSIXPath(value), // transform input parameter
+                        getAbsolutePOSIXPath('./datagen/db.json') // default value
                     )
                     .action(compileAction)
 

--- a/src/commands/exportFirestore.ts
+++ b/src/commands/exportFirestore.ts
@@ -6,6 +6,7 @@ import pluralize from 'pluralize'
 import * as path from 'path'
 import { errorStyle, infoStyle } from '../textStyles';
 import { TOOL_NAME } from '../constants';
+import { getAbsolutePOSIXPath } from '../utils/absolutePosixPath';
 
 // Options for the export-firestore command
 interface ExportFirestoreOptions {
@@ -15,10 +16,8 @@ interface ExportFirestoreOptions {
 const exportFirestoreAction = async (options: ExportFirestoreOptions) => {
     let serviceAccount = {}
 
-    const absoluteKeyPath = path.resolve(options.keypath)
-
     try {
-        serviceAccount = require(absoluteKeyPath)
+        serviceAccount = require(options.keypath)
     } catch (error: any) {
         if (error.code === 'MODULE_NOT_FOUND') {
             console.error(errorStyle(`The serviceAccountKey was not found at ${options.keypath}`))   
@@ -34,7 +33,7 @@ const exportFirestoreAction = async (options: ExportFirestoreOptions) => {
 
     let filenames: string[] = []
     try {
-        const absoluteDataDirectoryPath = path.resolve('./datagen')
+        const absoluteDataDirectoryPath = getAbsolutePOSIXPath('./datagen')
         filenames = await fsPromises.readdir(absoluteDataDirectoryPath, {
             recursive: false
         })
@@ -58,7 +57,7 @@ const exportFirestoreAction = async (options: ExportFirestoreOptions) => {
         console.log(infoStyle(`Adding documents from ./datagen/${filename} to collection "${collectionName}"`));
         
 
-        const absoluteFilePath = path.resolve(`./datagen/${filename}`)
+        const absoluteFilePath = getAbsolutePOSIXPath(`./datagen/${filename}`)
         const data: object[] = require(absoluteFilePath)
 
         data.forEach(async obj => {
@@ -75,7 +74,7 @@ const exportFirestoreCommand = new Command()
                     .requiredOption(
                         '-k, --keypath <path>',
                         'The path to your service account key JSON file',
-                        (value: any) => path.resolve(value)
+                        (value: any) => getAbsolutePOSIXPath(value) // transform input parameter
                     )
                     .action(exportFirestoreAction)
 

--- a/src/utils/absolutePosixPath.ts
+++ b/src/utils/absolutePosixPath.ts
@@ -1,0 +1,10 @@
+import path from 'path'
+
+export const getAbsolutePOSIXPath = (value: string) => {
+
+    // Get absolute path
+    const absolutePath = path.resolve(value)
+
+    // Return path with POSIX separators
+    return absolutePath.split(path.sep).join(path.posix.sep)
+}


### PR DESCRIPTION
- Added a feature that allows users to use external dependencies in the code they write within `@generate` directives. Users will use the `--dependency-script` flag in the `gqlfake generate` command to point to a custom Javascript file which exports the dependencies they want to use.
- UTIL: Added a function that, given a path, returns the absolute POSIX-formatted path.